### PR TITLE
build(deps): bump brace-expansion package version 1.1.11 to 1.1.14

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1836,12 +1836,12 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.11
-  resolution: "brace-expansion@npm:1.1.11"
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
+  checksum: 10/2de747a5891ea0d3a1946ea1ae26e056a47f7ea8d42a3009e1736ec3a31a5aa69a3c5da59d998426773553afe4c258e5b12d7953b534fa7f2cf12ce92eed4931
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
📝 **Description**

Major vulnerability in brace-expansion: Zero-step sequence causes process hang and memory exhaustion.

🔍 **Type of Change**

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue, e.g., fixing a false positive)
- [ ] ✨ New feature (e.g. new config or rule addition)
- [ ] 💥 Breaking change (e.g., turning a 'warn' into an 'error', or removing a rule entirely)
- [ ] 📚 Documentation update
- [x] 🛠️ Refactoring / Chore (e.g. dependency updates, internal scripts)

✅ **Checklist**

- [x] I have targeted the `canary` branch.
- [x] My PR title follows the Conventional Commits standard.
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have run `yarn install` to ensure lockfile integrity (if dependencies changed).
- [x] I have run `yarn typecheck` and `yarn build` successfully.
- [x] I have run `yarn lint:fix` and my changes generate no new linting errors.
