### PR TITLE
Release v2.1.0 (DX improvements and strictness relaxation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-woofmeow",
-  "version": "2.1.0-canary.0",
+  "version": "2.1.0",
   "description": "A modular ESLint Flat Config for modern JS/TS projects. Includes presets for React, Next.js, Tailwind CSS, FSD, Atomic Design, and JSON.",
   "license": "MIT",
   "author": "Oleg Putseiko <oleg.putseiko@gmail.com> (https://github.com/oleg-putseiko)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-woofmeow",
-  "version": "2.0.0",
+  "version": "2.1.0-canary.0",
   "description": "A modular ESLint Flat Config for modern JS/TS projects. Includes presets for React, Next.js, Tailwind CSS, FSD, Atomic Design, and JSON.",
   "license": "MIT",
   "author": "Oleg Putseiko <oleg.putseiko@gmail.com> (https://github.com/oleg-putseiko)",

--- a/src/configs/next.ts
+++ b/src/configs/next.ts
@@ -18,17 +18,28 @@ const configs: Linter.Config[] = [
       },
     },
   },
+
+  {
+    files: [
+      '**/app/**/{page,layout,loading,error,not-found,global-error,template}.{ts,tsx}',
+      '**/app/**/route.{ts,tsx}',
+      '**/pages/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-exports': 'off',
+    },
+  },
 ].map<Linter.Config>((config) => {
   const formattedConfig = {
     ...config,
-    files: ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
+    files: config.files ?? ['**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'],
   };
 
-  if (formattedConfig.plugins?.['@typescript-eslint']) {
+  if ('plugins' in formattedConfig && formattedConfig.plugins?.['@typescript-eslint']) {
     formattedConfig.plugins['@typescript-eslint'] = tseslint.plugin;
   }
 
-  return formattedConfig;
+  return formattedConfig as Linter.Config;
 });
 
 export default configs;

--- a/src/configs/react.ts
+++ b/src/configs/react.ts
@@ -64,6 +64,7 @@ const configs: Linter.Config[] = [
       'react/no-this-in-sfc': 'error',
       'react/no-unstable-nested-components': 'error',
       'react/no-unused-prop-types': 'error',
+      'react/prop-types': 'off',
       'react/self-closing-comp': ['warn', { component: true, html: true }],
       'react/void-dom-elements-no-children': 'error',
       'react-hooks/exhaustive-deps': 'off',

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -91,6 +91,7 @@ const configs: Linter.Config[] = [
       'unicorn/no-array-callback-reference': 'off',
       'unicorn/no-array-reduce': 'off',
       'unicorn/no-null': 'off',
+      'unicorn/prefer-at': 'off',
       'unicorn/prefer-node-protocol': 'warn',
       'unicorn/prefer-array-find': 'error',
       'unicorn/prefer-dom-node-append': 'error',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -33,6 +33,7 @@ const configs: Linter.Config[] = [
       },
     },
     rules: {
+      '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/consistent-type-definitions': 'off',
       '@typescript-eslint/consistent-type-imports': [
         'error',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -64,6 +64,7 @@ const configs: Linter.Config[] = [
         },
       ],
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
+      '@typescript-eslint/unbound-method': 'off',
       'no-undef': 'off',
       'no-unused-vars': 'off',
     },

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -48,6 +48,17 @@ const configs: Linter.Config[] = [
         'warn',
         { ignorePrimitives: true, ignoreBooleanCoercion: true },
       ],
+      '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+          allowAny: true,
+          allowArray: true,
+          allowBoolean: true,
+          allowNever: true,
+          allowNullish: true,
+          allowNumber: true,
+        },
+      ],
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
       'no-undef': 'off',
       'no-unused-vars': 'off',

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -40,6 +40,10 @@ const configs: Linter.Config[] = [
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
       ],
       '@typescript-eslint/explicit-module-boundary-types': 'off',
+      '@typescript-eslint/no-empty-function': [
+        'warn',
+        { allow: ['constructors', 'arrowFunctions'] },
+      ],
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { vars: 'all', varsIgnorePattern: '^_', args: 'after-used', argsIgnorePattern: '^_' },


### PR DESCRIPTION
📝 **Description**

This PR introduces changes aimed at improving Developer Experience (DX) and adapting the linter for modern frameworks (Next.js, NestJS, React). Overly strict rules have been disabled or relaxed to reduce false positives and prevent blocking development.

**Changed Rules:**
* `unicorn/prefer-at`: Disabled.
* `@typescript-eslint/unbound-method`: Disabled.
* `@typescript-eslint/no-empty-function`: Downgraded to `warn` (with exceptions).
* `@typescript-eslint/restrict-template-expressions`: Relaxed (safe types allowed).
* `@typescript-eslint/consistent-indexed-object-style`: Disabled.
* `react/prop-types`: Disabled.
* `no-restricted-exports`: Disabled for Next.js system router files.

🔍 **Type of Change**

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue, e.g., fixing a false positive)
- [x] ✨ New feature (e.g. new config or rule addition)
- [ ] 💥 Breaking change (e.g., turning a 'warn' into an 'error', or removing a rule entirely)
- [ ] 📚 Documentation update
- [ ] 🛠️ Refactoring / Chore (e.g. dependency updates, internal scripts)

✅ **Checklist**

- [x] My commit messages follow the Conventional Commits standard.
- [x] I have read the `CONTRIBUTING.md` document.
- [x] I have run `yarn install` to ensure lockfile integrity (if dependencies changed).
- [x] I have run `yarn typecheck` and `yarn build` successfully.
- [x] I have run `yarn lint:fix` and my changes generate no new linting errors.

🧪 **How Has This Been Tested?**

- [x] Tested locally by applying the updated config to a sample file and verifying the ESLint output.
